### PR TITLE
Add indicator to show whether a player is connected.

### DIFF
--- a/value_sensors/player_locations.lua
+++ b/value_sensors/player_locations.lua
@@ -121,6 +121,10 @@ function sensor:update_ui(owner)
 
         table.insert(desc, p.name)
 
+        if p.connected == false then
+			table.insert(desc, " [Offline]")
+        end
+
         if sensor_settings.show_position or sensor_settings.show_surface then
             table.insert(desc, ' (')
             if sensor_settings.show_position then


### PR DESCRIPTION
The player list currently shows all players known to a server, regardless of whether they're actually online or not.

This patch adds puts "[Offline]" after the name of anyone who isn't currently connected to the server.