### PR TITLE
More sensor configurations: play_time and evolution_factor.

### DIFF
--- a/evoGUI.lua
+++ b/evoGUI.lua
@@ -81,6 +81,12 @@ function evogui.create_player_globals(player)
             ['minute_rounding'] = true,
         }
     end
+
+    if not player_settings.sensor_settings['evolution_factor'] then
+        player_settings.sensor_settings['evolution_factor'] = {
+            ['extra_precision'] = false,
+        }
+    end
 end
 
 

--- a/evoGUI.lua
+++ b/evoGUI.lua
@@ -87,6 +87,13 @@ function evogui.create_player_globals(player)
             ['extra_precision'] = false,
         }
     end
+
+    if not player_settings.sensor_settings['play_time'] then
+        player_settings.sensor_settings['play_time'] = {
+            ['show_days'] = true,
+            ['show_seconds'] = true,
+        }
+    end
 end
 
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -7,6 +7,8 @@ sensor.day_time.settings.minute_rounding=Round displayed minutes to a quarter ho
 
 sensor.evolution_factor.name=Evolution factor
 sensor.evolution_factor.format=Biter evolution: __1__.
+sensor.evolution_factor.settings.title=Evolution factor display settings
+sensor.evolution_factor.settings.extra_precision=Show four decimals (x.1234%) instead of one (x.1%).
 
 sensor.play_time.name=Time played
 sensor.play_time.format=Play time: __1__.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -12,6 +12,11 @@ sensor.evolution_factor.settings.extra_precision=Show four decimals (x.1234%) in
 
 sensor.play_time.name=Time played
 sensor.play_time.format=Play time: __1__.
+sensor.play_time.single_day_fragment=1 day,
+sensor.play_time.multi_day_fragment=__1__ days,
+sensor.play_time.settings.title=Playing time settings
+sensor.play_time.settings.show_days=Show days ("2 days, 01:00" instead of "49:00")
+sensor.play_time.settings.show_seconds=Show seconds ("hh:mm:ss" instead of "hh:mm").
 
 sensor.player_locations.name=Player locations
 sensor.player_locations.format=Players:

--- a/value_sensors/day_time.lua
+++ b/value_sensors/day_time.lua
@@ -4,16 +4,6 @@ if not evogui.on_click then evogui.on_click = {} end
 local sensor = ValueSensor.new("day_time")
 
 
-function sensor:update_ui(owner)
-    local player = game.get_player(owner.player_index)
-    local sensor_settings = global.evogui[player.name].sensor_settings[self.name]
-
-    self.settings = sensor_settings
-
-    owner[self.name].caption = self:get_line()
-end
-
-
 function sensor:get_line()
     -- 0.5 is midnight; let's make days *start* at midnight instead.
     local day_time = math.fmod(game.daytime + 0.5, 1)

--- a/value_sensors/day_time.lua
+++ b/value_sensors/day_time.lua
@@ -32,16 +32,6 @@ function sensor:get_line()
 end
 
 
-function sensor:close_settings_gui(player_index)
-    local player = game.get_player(player_index)
-    local root_name = self:settings_root_name()
-
-    player.gui.center[root_name].destroy()
-
-    if self.settings_gui_closed then self.settings_gui_closed(player_index) end
-end
-
-
 function sensor:settings_gui(player_index)
     local player = game.get_player(player_index)
     local sensor_settings = global.evogui[player.name].sensor_settings[self.name]

--- a/value_sensors/evolution_factor.lua
+++ b/value_sensors/evolution_factor.lua
@@ -2,8 +2,32 @@ require "template"
 
 local sensor = ValueSensor.new("evolution_factor")
 
+
 function sensor:get_line()
+    if self.settings.extra_precision then
+        return {self.format_key, string.format("%0.4f%%", game.evolution_factor * 100)}
+    end
+
     return {self.format_key, string.format("%0.1f%%", game.evolution_factor * 100)}
+end
+
+
+function sensor:settings_gui(player_index)
+    local player = game.get_player(player_index)
+    local sensor_settings = global.evogui[player.name].sensor_settings[self.name]
+    local root_name = self:settings_root_name()
+
+    local root = player.gui.center.add{type="frame",
+                                       name=root_name,
+                                       direction="vertical",
+                                       caption={"sensor.evolution_factor.settings.title"}}
+    root.add{type="checkbox", name="evogui_extra_precision",
+             caption={"sensor.evolution_factor.settings.extra_precision"},
+             state=sensor_settings.extra_precision}
+    evogui.on_click.evogui_extra_precision = self:make_on_click_checkbox_handler("extra_precision")
+
+    local btn_close = root.add{type="button", name="evogui_custom_sensor_close", caption={"settings_close"}}
+    evogui.on_click[btn_close.name] = function(event) self:close_settings_gui(player_index) end
 end
 
 ValueSensor.register(sensor)

--- a/value_sensors/play_time.lua
+++ b/value_sensors/play_time.lua
@@ -2,13 +2,56 @@ require "template"
 
 local sensor = ValueSensor.new("play_time")
 
+
 function sensor:get_line()
     local play_time_seconds = math.floor(game.tick/60)
     local play_time_minutes = math.floor(play_time_seconds/60)
     local play_time_hours = math.floor(play_time_minutes/60)
+    local play_time_days = math.floor(play_time_hours/24)
 
-    return {self.format_key,
-            string.format("%d:%02d:%02d", play_time_hours, play_time_minutes % 60, play_time_seconds % 60)}
+    local desc = {""}
+    if play_time_days > 0 and self.settings.show_days then
+        if play_time_days == 1 then
+            table.insert(desc, {"sensor.play_time.single_day_fragment"})
+        else
+            table.insert(desc, {"sensor.play_time.multi_day_fragment", tostring(play_time_days)})
+        end
+        table.insert(desc, ' ')
+        play_time_hours = play_time_hours % 24
+    end
+
+    if self.settings.show_seconds then
+        table.insert(desc, string.format("%d:%02d:%02d", play_time_hours, play_time_minutes % 60, play_time_seconds % 60))
+    else
+        table.insert(desc, string.format("%d:%02d", play_time_hours, play_time_minutes % 60))
+    end
+
+    return {self.format_key, desc}
 end
+
+
+function sensor:settings_gui(player_index)
+    local player = game.get_player(player_index)
+    local sensor_settings = global.evogui[player.name].sensor_settings[self.name]
+    local root_name = self:settings_root_name()
+
+    local root = player.gui.center.add{type="frame",
+                                       name=root_name,
+                                       direction="vertical",
+                                       caption={"sensor.play_time.settings.title"}}
+    root.add{type="checkbox", name="evogui_show_days",
+             caption={"sensor.play_time.settings.show_days"},
+             state=sensor_settings.show_days}
+    evogui.on_click.evogui_show_days = self:make_on_click_checkbox_handler("show_days")
+
+    root.add{type="checkbox", name="evogui_show_seconds",
+             caption={"sensor.play_time.settings.show_seconds"},
+             state=sensor_settings.show_seconds}
+    evogui.on_click.evogui_show_seconds = self:make_on_click_checkbox_handler("show_seconds")
+
+    local btn_close = root.add{type="button", name="evogui_custom_sensor_close", caption={"settings_close"}}
+    evogui.on_click[btn_close.name] = function(event) self:close_settings_gui(player_index) end
+end
+
 
 ValueSensor.register(sensor)

--- a/value_sensors/player_locations.lua
+++ b/value_sensors/player_locations.lua
@@ -3,6 +3,7 @@ require "template"
 if not evogui.on_click then evogui.on_click = {} end
 local sensor = ValueSensor.new("player_locations")
 
+
 function sensor:create_ui(owner)
     if owner[self.name] == nil then
         local root = owner.add{type="flow",
@@ -13,16 +14,6 @@ function sensor:create_ui(owner)
         root.add{type="label", caption={self.format_key}}
         root.add{type="table", name="player_list", colspan=1}
     end
-end
-
-
-function sensor:close_settings_gui(player_index)
-    local player = game.get_player(player_index)
-    local root_name = self:settings_root_name()
-
-    player.gui.center[root_name].destroy()
-
-    if self.settings_gui_closed then self.settings_gui_closed(player_index) end
 end
 
 

--- a/value_sensors/template.lua
+++ b/value_sensors/template.lua
@@ -40,6 +40,15 @@ function ValueSensor.new(name)
         return self.name.."_settings"
     end
 
+    function sensor:close_settings_gui(player_index)
+        local player = game.get_player(player_index)
+        local root_name = self:settings_root_name()
+
+        player.gui.center[root_name].destroy()
+
+        if self.settings_gui_closed then self.settings_gui_closed(player_index) end
+    end
+
     function sensor:make_on_click_checkbox_handler(setting_name)
         local sensor_name = self.name
 

--- a/value_sensors/template.lua
+++ b/value_sensors/template.lua
@@ -22,6 +22,11 @@ function ValueSensor.new(name)
     end
 
     function sensor:update_ui(owner)
+        local player = game.get_player(owner.player_index)
+        local sensor_settings = global.evogui[player.name].sensor_settings[self.name]
+
+        self.settings = sensor_settings
+
         owner[self.name].caption = self:get_line()
     end
 


### PR DESCRIPTION
As requested in #21 and #22, the play time and evolution factor sensors now have their own config:

- Playing time: can now show days (if over 24 hours played) and hide seconds (for those preferring `h:mm` to `h:mm:ss`).
- Evolution factor: can now show four digits of precision instead of one.

A bit of rearrangement has also been done to make the code cleaner; in particular, the value_sensor template now knows how to do the invariant parts of per-sensor settings, so each sensor need only define how their settings GUI looks, and react to settings defined in `self.settings`.

Special mention for #23: more locale bits have been added yet again.