### PR TITLE
Updated Hebrew translation for 0.4.8

### DIFF
--- a/locale/he/locale.cfg
+++ b/locale/he/locale.cfg
@@ -78,3 +78,10 @@ err_settings_whatsettings=__1__ called for settings-less sensor! הרדגה אל
 err_needplayername=!שמתשמ םש ךירצ [EvoGUI]
 err_nosuchplayer=__1__! :ןקחש הזכ ןיא [EvoGUI]
 err_noplayerdata=__1__! :ןקחש לע עדימ ןיא [EvoGUI]
+
+err_nosensorname=ןשייח םש רסח name! sensor a Missing [EvoGUI]
+err_no_sensor_data=ןשייח עדימ רסח data! sensor remote Missing [EvoGUI]
+err_sensor_missing_field=__2__ ץוחנ הדש רסח __1__ ןשייחל __2__! field required a missing is __1__ sensor Remote [EvoGUI]
+err_nosensortext=ןשייחל טסקט רסח __1__! for text sensor Missing [EvoGUI]
+err_nosensorcaption=ןשייחל תרתוכ רסח __1__! for text caption Missing [EvoGUI]
+err_nosensorfound=ןשייח רוציל שי תישאר .אצמנ אל __1__ םש םע ןשייח first. sensor a Create __1__! name the matching sensor No [EvoGUI]


### PR DESCRIPTION
In regards to #23 - 

 Added latest error messages with a hebrew translation. As usual, I leave
the english message and add hebrew to acommodate the Hebrew speaking
crowd and enable an easy way to search for a fix