### PR TITLE
Create player settings if missing due to converting an existing SP game to a MP game

### DIFF
--- a/evoGUI.lua
+++ b/evoGUI.lua
@@ -68,6 +68,10 @@ end
 function evogui.new_player(event)
     local player = game.get_player(event.player_index)
 
+    setup_player(player)
+end
+
+function evogui.setup_player(player)
     evogui.create_player_globals(player)
     evogui.create_sensor_display(player)
 end
@@ -78,6 +82,10 @@ function evogui.update_gui(event)
 
     for _, player in pairs(game.players) do
         local player_settings = global.evogui[player.name]
+        if not player_settings then
+            evogui.setup_player(player)
+            player_settings = global.evogui[player.name]
+        end
 
         local sensor_flow = player.gui.top.evoGUI.sensor_flow
         evogui.update_av(player, sensor_flow.always_visible)


### PR DESCRIPTION
The issue here is that in a SP save, the player's name is empty string (""), and in a MP game (even a MP game with only 1 player), the player's name is their actual Factorio account name. This means the settings for the SP player, created for the player with the name empty string do not exist in MP for the player with a regular name, even though Factorio considers these to be the same players, and do not fire any particular on_player_created event or other sort of notice. So after loading a previously existing SP save in a MP game, EvoGui will error repeatedly due to trying to index into nil data from the bad key.

That leaves the only possible option to catch this unfortunate occurrence in the on_tick and create the player data as needed.