### PR TITLE
Remove floating point string formatting for multiplayer multiplatform compatibility, fixes issue #34 

### DIFF
--- a/value_sensors/evolution_factor.lua
+++ b/value_sensors/evolution_factor.lua
@@ -4,11 +4,15 @@ local sensor = ValueSensor.new("evolution_factor")
 
 
 function sensor:get_line()
+    local percent_evo_factor = game.evolution_factor * 100
+    -- this nonsense is because string.format(%.4f) is not safe in MP across platforms, but integer math is
+    local whole_number = math.floor(percent_evo_factor)
+    local fractional_component = math.floor((percent_evo_factor - whole_number) * 10)
     if self.settings.extra_precision then
-        return {self.format_key, string.format("%0.4f%%", game.evolution_factor * 100)}
+        fractional_component = math.floor((percent_evo_factor - whole_number) * 10000)
     end
 
-    return {self.format_key, string.format("%0.1f%%", game.evolution_factor * 100)}
+    return {self.format_key, string.format("%d.%d%%", whole_number, fractional_component)}
 end
 
 

--- a/value_sensors/pollution_around_player.lua
+++ b/value_sensors/pollution_around_player.lua
@@ -10,12 +10,13 @@ function PollutionSensor.new(player)
     function sensor:get_line()
         local surface = self.player.surface
         local pollution = surface.get_pollution(self.player.position)
-
-        return {self.format_key, string.format("%0.1f", pollution)}
+        
+        -- this nonsense is because string.format(%.1f) is not safe in MP across platforms, but integer math is
+        local whole_number = math.floor(pollution)
+        local fractional_component = math.floor((pollution - whole_number) * 10)
+        
+        return {self.format_key, (whole_number .. "." .. fractional_component)}
     end
 
     return sensor
 end
-
-
-


### PR DESCRIPTION
The only sensor using floating points was the evolution factor and pollution around player sensors. Day time, kill count, player locations, and play time all used integers already.

I believe the main problem with floats is that the string.format (which essentially just calls the system library printf or similar) is platform-dependent. This is supported by FFF 108: https://www.factorio.com/blog/post/fff-108 . The gist of the problem, as I understand it, is that the system library may return differing values for Linux, Mac, and Windows. However, there is no differing return values for integers, so doing mathematical trickery to break a floating point number into two integers (the whole number component and fractional decimal component), and printing a floating number as a string made up of two integers should side-step the platform-dependency issues. This fixes #34 [reformatted for auto-close -Narc].

Possibly in the future when Factorio moves to LuaJIT, this will go away (as LuaJIT has it's own platform-independent string formatter), but for now, this code is needed.