### PR TITLE
Allow player_locations sensor to work in older Factorio saves with no player name

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -21,6 +21,7 @@ sensor.play_time.settings.show_seconds=Show seconds ("hh:mm:ss" instead of "hh:m
 sensor.player_locations.name=Player locations
 sensor.player_locations.format=Players:
 sensor.player_locations.err_no_name=You have no multiplayer username, player list disabled.
+sensor.player_locations.local_player=Local player
 sensor.player_locations.surface_fragment=on __1__
 sensor.player_locations.offline_fragment=[Offline]
 sensor.player_locations.settings.title=Player location settings

--- a/value_sensors/player_locations.lua
+++ b/value_sensors/player_locations.lua
@@ -75,24 +75,30 @@ function sensor:update_ui(owner)
     local gui_list = owner[self.name].player_list
 
     for _, p in ipairs(game.players) do
-        if not p.name or p.name == '' then
-            if gui_list.error == nil then
-                gui_list.add{type="label", name="error", caption={"sensor.player_locations.err_no_name"}}
+        local player_name = p.name
+        if not player_name or player_name == '' then
+            -- fallback to "Local Player" if this is singleplayer
+            if #game.players == 1 then
+                player_name = "sensor.player_locations.local_player"
+            else
+                if gui_list.error == nil then
+                    gui_list.add{type="label", name="error", caption={"sensor.player_locations.err_no_name"}}
+                end
+                break
             end
-            break
         end
 
         if gui_list.error ~= nil then gui_list.error.destroy() end
 
         if p.connected == false and not sensor_settings.show_offline then
-            if gui_list[p.name] and gui_list[p.name].valid then
-                gui_list[p.name].destroy()
+            if gui_list[player_name] and gui_list[player_name].valid then
+                gui_list[player_name].destroy()
             end
             goto next_player
         end
 
-        if gui_list[p.name] == nil then
-            gui_list.add{type="label", name=p.name}
+        if gui_list[player_name] == nil then
+            gui_list.add{type="label", name=player_name}
         end
 
         local direction = '?'
@@ -108,7 +114,11 @@ function sensor:update_ui(owner)
             table.insert(desc, string.format('(%d) ', p.index))
         end
 
-        table.insert(desc, p.name)
+        if player_name == "sensor.player_locations.local_player" then
+            table.insert(desc, {player_name})
+        else
+            table.insert(desc, player_name)
+        end
 
         if p.connected == false then
             table.insert(desc, ' ')
@@ -134,7 +144,7 @@ function sensor:update_ui(owner)
             table.insert(desc, direction)
         end
 
-        gui_list[p.name].caption = desc
+        gui_list[player_name].caption = desc
         ::next_player::
     end
 end


### PR DESCRIPTION
I know new SP games in Factorio 0.12.22 create the local player with the username, but older saves from 0.11 or older do not, and player_locations don't work as a result. This is a tiny tweak to fall back to "Local player" when no player name is available and only 1 player exists in the game (single_player). 