### PR TITLE
Create the setting handlers immediately, instead of when a gui is opened

### DIFF
--- a/value_sensors/day_time.lua
+++ b/value_sensors/day_time.lua
@@ -10,6 +10,9 @@ else
     function get_day_time() return game.daytime + 0.5 end
 end
 
+sensor.show_day_number = sensor:make_on_click_checkbox_handler("show_day_number")
+sensor.minute_rounding = sensor:make_on_click_checkbox_handler("minute_rounding")
+
 function sensor:get_line(player)
     local day_time = math.fmod(get_day_time(), 1)
 
@@ -49,12 +52,10 @@ function sensor:settings_gui(player_index)
     root.add{type="checkbox", name="evogui_sensor_day_time_checkbox_show_day_number",
              caption={"sensor.day_time.settings.show_day_number"},
              state=sensor_settings.show_day_number}
-    self.show_day_number = self:make_on_click_checkbox_handler("show_day_number")
 
     root.add{type="checkbox", name="evogui_sensor_day_time_checkbox_minute_rounding",
              caption={"sensor.day_time.settings.minute_rounding"},
              state=sensor_settings.minute_rounding}
-    self.minute_rounding = self:make_on_click_checkbox_handler("minute_rounding")
 
     root.add{type="button", name="evogui_sensor_day_time_btn_close", caption={"settings_close"}}
 end

--- a/value_sensors/evolution_factor.lua
+++ b/value_sensors/evolution_factor.lua
@@ -1,7 +1,7 @@
 require "template"
 
 local sensor = ValueSensor.new("evolution_factor")
-
+sensor.extra_precision = sensor:make_on_click_checkbox_handler("extra_precision")
 
 function sensor:get_line(player)
     local percent_evo_factor = game.evolution_factor * 100
@@ -28,7 +28,6 @@ function sensor:settings_gui(player_index)
     root.add{type="checkbox", name="evogui_sensor_evolution_factor_checkbox_extra_precision",
              caption={"sensor.evolution_factor.settings.extra_precision"},
              state=sensor_settings.extra_precision}
-    self.extra_precision = self:make_on_click_checkbox_handler("extra_precision")
 
     root.add{type="button", name="evogui_sensor_evolution_factor_close", caption={"settings_close"}}
 end

--- a/value_sensors/play_time.lua
+++ b/value_sensors/play_time.lua
@@ -1,6 +1,8 @@
 require "template"
 
 local sensor = ValueSensor.new("play_time")
+sensor.show_days = sensor:make_on_click_checkbox_handler("show_days")
+sensor.show_seconds = sensor:make_on_click_checkbox_handler("show_seconds")
 
 
 function sensor:get_line(player)
@@ -42,12 +44,10 @@ function sensor:settings_gui(player_index)
     root.add{type="checkbox", name="evogui_sensor_play_time_checkbox_show_days",
              caption={"sensor.play_time.settings.show_days"},
              state=sensor_settings.show_days}
-    self.show_days = self:make_on_click_checkbox_handler("show_days")
 
     root.add{type="checkbox", name="evogui_sensor_play_time_checkbox_show_seconds",
              caption={"sensor.play_time.settings.show_seconds"},
              state=sensor_settings.show_seconds}
-    self.show_seconds = self:make_on_click_checkbox_handler("show_seconds")
 
     root.add{type="button", name="evogui_sensor_play_time_close", caption={"settings_close"}}
 end

--- a/value_sensors/player_locations.lua
+++ b/value_sensors/player_locations.lua
@@ -2,6 +2,11 @@ require "template"
 
 if not evogui.on_click then evogui.on_click = {} end
 local sensor = ValueSensor.new("player_locations")
+sensor.show_player_index = sensor:make_on_click_checkbox_handler("show_player_index")
+sensor.show_position = sensor:make_on_click_checkbox_handler("show_position")
+sensor.show_surface = sensor:make_on_click_checkbox_handler("show_surface")
+sensor.show_direction = sensor:make_on_click_checkbox_handler("show_direction")
+sensor.show_offline = sensor:make_on_click_checkbox_handler("show_offline")
 
 
 function sensor:create_ui(owner)
@@ -29,27 +34,22 @@ function sensor:settings_gui(player_index)
     root.add{type="checkbox", name="evogui_sensor_player_locations_checkbox_show_player_index",
              caption={"sensor.player_locations.settings.show_player_index"},
              state=sensor_settings.show_player_index}
-    self.show_player_index = self:make_on_click_checkbox_handler("show_player_index")
 
     root.add{type="checkbox", name="evogui_sensor_player_locations_checkbox_show_position",
              caption={"sensor.player_locations.settings.show_position"},
              state=sensor_settings.show_position}
-    self.show_position = self:make_on_click_checkbox_handler("show_position")
 
     root.add{type="checkbox", name="evogui_sensor_player_locations_checkbox_show_surface",
              caption={"sensor.player_locations.settings.show_surface"},
              state=sensor_settings.show_surface}
-    self.show_surface = self:make_on_click_checkbox_handler("show_surface")
 
     root.add{type="checkbox", name="evogui_sensor_player_locations_checkbox_show_direction",
              caption={"sensor.player_locations.settings.show_direction"},
              state=sensor_settings.show_direction}
-    self.show_direction = self:make_on_click_checkbox_handler("show_direction")
 
     root.add{type="checkbox", name="evogui_sensor_player_locations_checkbox_show_offline",
              caption={"sensor.player_locations.settings.show_offline"},
              state=sensor_settings.show_offline}
-    self.show_offline = self:make_on_click_checkbox_handler("show_offline")
 
     root.add{type="button", name="evogui_sensor_player_locations_close", caption={"settings_close"}}
 end


### PR DESCRIPTION
Fixes an issue I missed in PR #50